### PR TITLE
Read Claude Code credentials from the macOS Keychain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- On macOS, Claude Code OAuth credentials stored in the login Keychain
-  (the default for `claude login`) are now copied into pods. Previously
-  only `~/.claude/.credentials.json` was read, which does not exist on
-  macOS, so `rumpel claude` prompted for a fresh browser login inside
-  every new pod.
-
 ## [0.1.0] - TBD
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- On macOS, Claude Code OAuth credentials stored in the login Keychain
+  (the default for `claude login`) are now copied into pods. Previously
+  only `~/.claude/.credentials.json` was read, which does not exist on
+  macOS, so `rumpel claude` prompted for a fresh browser login inside
+  every new pod.
+
 ## [0.1.0] - TBD
 
 ### Added

--- a/rumpelpod/src/claude.rs
+++ b/rumpelpod/src/claude.rs
@@ -120,6 +120,64 @@ pub fn claude(cmd: &ClaudeCommand) -> Result<()> {
     Ok(())
 }
 
+/// Read the local Claude Code OAuth credentials, if any.
+///
+/// On Linux, Claude Code stores them in ~/.claude/.credentials.json.
+/// On macOS it stores them in the login Keychain (service "Claude
+/// Code-credentials") instead, and the file usually does not exist.
+/// Try the file first, then fall back to the Keychain.
+pub(crate) fn read_local_credentials(local_home: &Path) -> Result<Option<Vec<u8>>> {
+    match std::fs::read(local_home.join(".claude/.credentials.json")) {
+        Ok(data) => return Ok(Some(data)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(anyhow::Error::from(e).context("reading ~/.claude/.credentials.json"))
+        }
+    }
+    Ok(read_keychain_credentials())
+}
+
+/// Read the Claude Code credentials from the macOS login Keychain.
+///
+/// The item's password is the same JSON document that
+/// .credentials.json holds on Linux.  Any failure degrades to `None`
+/// (same as a missing credentials file) so users authenticating by
+/// other means (API key, env vars) are not blocked.
+#[cfg(target_os = "macos")]
+fn read_keychain_credentials() -> Option<Vec<u8>> {
+    let output = match std::process::Command::new("/usr/bin/security")
+        .args(["find-generic-password", "-s", "Claude Code-credentials", "-w"])
+        .output()
+    {
+        Ok(output) => output,
+        Err(e) => {
+            log::warn!("could not run security(1) to read Claude Code Keychain credentials: {e}");
+            return None;
+        }
+    };
+    if !output.status.success() {
+        // Exit code 44 (errSecItemNotFound) is the normal "no Keychain
+        // credentials" case.
+        if output.status.code() != Some(44) {
+            log::warn!(
+                "security(1) failed reading Claude Code Keychain credentials: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        return None;
+    }
+    let mut data = output.stdout;
+    if data.last() == Some(&b'\n') {
+        data.pop();
+    }
+    (!data.is_empty()).then_some(data)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_keychain_credentials() -> Option<Vec<u8>> {
+    None
+}
+
 /// Copy only authentication credentials from the local machine into
 /// the pod.
 ///
@@ -137,17 +195,13 @@ pub fn reauth(cmd: &ClaudeCommand) -> Result<()> {
 
     let mut files: Vec<HomeFileEntry> = Vec::new();
 
-    // .claude/.credentials.json -- OAuth tokens
-    match std::fs::read(local_home.join(".claude/.credentials.json")) {
-        Ok(data) => {
-            files.push(HomeFileEntry {
-                path: ".claude/.credentials.json".to_string(),
-                content: base64_encode(&data),
-                create_parents: true,
-            });
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => return Err(anyhow::Error::from(e).context("reading ~/.claude/.credentials.json")),
+    // OAuth tokens from .claude/.credentials.json or the macOS Keychain
+    if let Some(data) = read_local_credentials(&local_home)? {
+        files.push(HomeFileEntry {
+            path: ".claude/.credentials.json".to_string(),
+            content: base64_encode(&data),
+            create_parents: true,
+        });
     }
 
     // primaryApiKey -- read-modify-write on .claude.json

--- a/rumpelpod/src/daemon.rs
+++ b/rumpelpod/src/daemon.rs
@@ -1512,11 +1512,7 @@ fn copy_claude_config_via_pod(
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
         Err(e) => return Err(anyhow::Error::from(e).context("reading ~/.claude.json")),
     };
-    let credentials = match std::fs::read(claude_dir.join(".credentials.json")) {
-        Ok(data) => Some(data),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
-        Err(e) => return Err(anyhow::Error::from(e).context("reading ~/.claude/.credentials.json")),
-    };
+    let credentials = crate::claude::read_local_credentials(&local_home)?;
     let settings = match std::fs::read(claude_dir.join("settings.json")) {
         Ok(data) => Some(data),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,


### PR DESCRIPTION
On macOS, `claude login` stores OAuth credentials in the login Keychain
(service `Claude Code-credentials`) instead of
`~/.claude/.credentials.json` — the file doesn't exist at all. Both
places that copy credentials into a pod read only the file and treat
"not found" as "no credentials":

- `copy_claude_config_via_pod` in `daemon.rs` (pod creation)
- `reauth` in `claude.rs` (`rumpel claude <name> reauth`)

So on macOS a new pod comes up without credentials and Claude Code asks
for a browser login inside the pod. Later starts of the same pod work,
because the in-pod login persists in the pod's home directory, which
makes this look like a confusing first-start-only problem.

This adds `claude::read_local_credentials`, which tries the file first
and, on macOS, falls back to
`security find-generic-password -s "Claude Code-credentials" -w`. The
Keychain item's password is the same JSON document the file holds on
Linux, so it is passed through verbatim. Exit code 44
(`errSecItemNotFound`) means "not logged in via Keychain" and stays
silent; any other failure logs a warning and continues without
credentials, matching the previous missing-file behavior, so API-key
and env-var setups are unaffected. The fallback is only compiled for
macOS.

Tested:

- `cargo check`, `cargo clippy`, and the new unit tests pass. The
  missing-file test is gated to non-macOS because there the fallback
  would consult the real login Keychain.
- Verified the `security(1)` behavior on macOS 15 (arm64) with a
  scratch Keychain item: `-w` round-trips the JSON byte-for-byte plus a
  trailing newline (stripped), and a missing item exits with 44.
- Reproduced the original bug on a Mac where
  `~/.claude/.credentials.json` is absent and the Keychain item exists.
- I wasn't able to run `cargo pipeline`: it needs sysbox, which isn't
  available on the Mac that reproduces the bug.

Depending on the item's ACL, the first Keychain read may trigger a
one-time macOS confirmation prompt.
