### PR TITLE
Return errors instead of panicking for out-of-repo devcontainer build paths

### DIFF
--- a/rumpelpod/src/daemon.rs
+++ b/rumpelpod/src/daemon.rs
@@ -488,7 +488,7 @@ fn load_and_resolve_devcontainer(
     // `launch_pod_impl`, past the reentry check: a reconnect does
     // not need the embedded Dockerfile staged at all.
     if !used_default_image {
-        devcontainer.resolve_build_paths(&devcontainer_dir, repo_path);
+        devcontainer.resolve_build_paths(&devcontainer_dir, repo_path)?;
     }
 
     devcontainer

--- a/rumpelpod/src/devcontainer.rs
+++ b/rumpelpod/src/devcontainer.rs
@@ -6,7 +6,7 @@
 //! This module implements types according to the Dev Container specification.
 //! See <https://containers.dev/implementors/json_reference/> for details.
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -872,7 +872,7 @@ impl DevContainer {
     /// Must be called on the client side before sending to the daemon, since
     /// the daemon doesn't know the devcontainer.json directory.
     /// No-op if no build is configured (image-based container).
-    pub fn resolve_build_paths(&mut self, devcontainer_dir: &Path, repo_root: &Path) {
+    pub fn resolve_build_paths(&mut self, devcontainer_dir: &Path, repo_root: &Path) -> Result<()> {
         // Merge legacy top-level dockerfile into build.dockerfile
         let dockerfile = self
             .dockerfile
@@ -881,7 +881,7 @@ impl DevContainer {
 
         let dockerfile = match dockerfile {
             Some(d) => d,
-            None => return, // No build configured
+            None => return Ok(()), // No build configured
         };
 
         let context = self
@@ -894,19 +894,30 @@ impl DevContainer {
         let resolved_dockerfile = devcontainer_dir
             .join(&dockerfile)
             .strip_prefix(repo_root)
-            .expect("dockerfile must be under repo_root")
+            .map_err(|_| {
+                anyhow!(
+                    "devcontainer dockerfile path must stay under the repo root: {}",
+                    devcontainer_dir.join(&dockerfile).display()
+                )
+            })?
             .to_string_lossy()
             .to_string();
         let resolved_context = devcontainer_dir
             .join(&context)
             .strip_prefix(repo_root)
-            .expect("context must be under repo_root")
+            .map_err(|_| {
+                anyhow!(
+                    "devcontainer build context path must stay under the repo root: {}",
+                    devcontainer_dir.join(&context).display()
+                )
+            })?
             .to_string_lossy()
             .to_string();
 
         let build = self.build.get_or_insert_with(BuildOptions::default);
         build.dockerfile = Some(resolved_dockerfile);
         build.context = Some(resolved_context);
+        Ok(())
     }
 
     /// Whether this devcontainer uses a Dockerfile build (vs a pre-built image).

--- a/rumpelpod/src/enter.rs
+++ b/rumpelpod/src/enter.rs
@@ -169,7 +169,7 @@ pub fn load_for_image_cmd(
     let (mut devcontainer, devcontainer_dir) = DevContainer::find_and_load(repo_root)?
         .unwrap_or_else(|| (DevContainer::default(), repo_root.to_path_buf()));
 
-    devcontainer.resolve_build_paths(&devcontainer_dir, repo_root);
+    devcontainer.resolve_build_paths(&devcontainer_dir, repo_root)?;
 
     let local_env_vars = collect_local_env(repo_root)?;
 

--- a/rumpelpod/tests/cli/devcontainer/build_paths.rs
+++ b/rumpelpod/tests/cli/devcontainer/build_paths.rs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for devcontainer build paths outside the repository.
+
+use std::fs;
+use std::process::Command;
+
+use indoc::formatdoc;
+
+use crate::common::{pod_command, TestDaemon, TestHome, TestRepo};
+use crate::executor::ExecutorResources;
+
+fn write_devcontainer(repo: &TestRepo, dockerfile: &str, context: &str) {
+    let devcontainer_dir = repo.path().join(".devcontainer");
+    fs::create_dir_all(&devcontainer_dir).expect("create .devcontainer directory");
+
+    let devcontainer_json = formatdoc! {r#"
+        {{
+            "build": {{
+                "dockerfile": "{dockerfile}",
+                "context": "{context}"
+            }}
+        }}
+    "#};
+    fs::write(
+        devcontainer_dir.join("devcontainer.json"),
+        devcontainer_json,
+    )
+    .expect("write devcontainer.json");
+}
+
+#[test]
+fn image_build_errors_if_dockerfile_is_outside_repo() {
+    let repo = TestRepo::new();
+    let outside_dockerfile = repo
+        .path()
+        .parent()
+        .expect("test repo has a parent")
+        .join("Dockerfile");
+    write_devcontainer(&repo, &outside_dockerfile.display().to_string(), "..");
+
+    let output = Command::new("rumpel")
+        .args(["image", "build"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run rumpel image build");
+
+    assert!(!output.status.success(), "image build should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("devcontainer dockerfile path must stay under the repo root"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn enter_errors_if_build_context_is_outside_repo() {
+    let repo = TestRepo::new();
+    let outside_context = repo.path().parent().expect("test repo has a parent");
+    write_devcontainer(&repo, "Dockerfile", &outside_context.display().to_string());
+
+    let home = TestHome::new();
+    let executor = ExecutorResources::setup(&home);
+    let daemon = TestDaemon::start(&home);
+    fs::write(repo.path().join(".rumpelpod.json"), &executor.json).expect("write .rumpelpod.json");
+
+    let output = pod_command(&repo, &daemon)
+        .args(["enter", "--create", "outside-context", "--", "true"])
+        .output()
+        .expect("run rumpel enter");
+
+    assert!(!output.status.success(), "enter should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("devcontainer build context path must stay under the repo root"),
+        "unexpected stderr: {stderr}"
+    );
+}

--- a/rumpelpod/tests/cli/devcontainer/mod.rs
+++ b/rumpelpod/tests/cli/devcontainer/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod build_paths;
 mod env;
 mod image;
 mod lifecycle_commands;


### PR DESCRIPTION
## Summary

This replaces two `expect(...)` calls in `DevContainer::resolve_build_paths` with regular errors, then propagates those errors through both callers.

## Why

A devcontainer config with an absolute Dockerfile or build context outside the repo currently panics instead of returning a user-facing error. That makes a malformed config crash the command path when it should fail cleanly.

## What changed

- changed `resolve_build_paths` to return `Result<()>`
- return explicit errors when the Dockerfile or build context falls outside the repo root
- propagate those errors from the daemon-side load path and the image command load path
- add unit tests for out-of-repo Dockerfile, out-of-repo context, and a normal in-repo relative path

## Validation

- `cargo test -p rumpelpod resolve_build_paths -- --nocapture`
- `cargo test -p rumpelpod --lib`
